### PR TITLE
修改为 ByteBuffer.allocate(8);

### DIFF
--- a/LinuxJavaCallNative.java
+++ b/LinuxJavaCallNative.java
@@ -186,7 +186,9 @@ public class LinuxJavaCallNative {
 		ret
 		*/
 		byte[] movabs_rax = {0x48, (byte) 0xb8};
-        ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
+        //  ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
+	//  Long.BYTES 是jdk8之后才有的，Long.BYTES = 8 所以直接修改成8可以获得更好的兼容性。
+	ByteBuffer buffer = ByteBuffer.allocate(8);
         buffer.order(ByteOrder.LITTLE_ENDIAN);
         buffer.putLong(0, JNI_GetCreatedJavaVMs);
         


### PR DESCRIPTION
Long.BYTES 是jdk8之后才有的，Long.BYTES = 8 所以直接修改成8可以获得更好的兼容性。